### PR TITLE
refactor: rename deploy job to build and add conditional deploy step …

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -31,6 +31,13 @@ jobs:
         run: npm run build
         working-directory: Proyecto/backend
 
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    # Solo ejecutar el job de deploy cuando es un push a main-backend, no en pull requests
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main-backend'
+
+    steps:
       - name: Deploy to DigitalOcean Droplet via SSH
         uses: appleboy/ssh-action@v0.1.10
         with:


### PR DESCRIPTION

This pull request includes updates to the GitHub Actions workflow configuration file `.github/workflows/nodejs.yml`. The changes focus on restructuring the jobs to separate the build and deploy processes, and adding conditions to the deploy job.

Changes to GitHub Actions workflow:

* Renamed the `deploy` job to `build` and added a new `deploy` job that depends on the `build` job.
* Added a condition to the `deploy` job to only run on pushes to the `main-backend` branch, ensuring it does not execute on pull requests.